### PR TITLE
Use yarn to install dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.14 AS builder
 WORKDIR /dpblog
 RUN npm i -g gatsby-cli
 COPY package*.json ./
-RUN npm install
+RUN yarn install
 COPY . .
 RUN gatsby build
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,17 @@ This is a static blog generator and starter gatsby repo. A port of [Casper](http
 
 ## Local build
 
+### Install yarn (Optional)
+Ignore if already installed.
+
 ```
-npm install
+npm install --global yarn
+```
+
+### Local dev
+
+```
+yarn install
 gatsby build
 gatsby develop
 ```


### PR DESCRIPTION
Avoid #75 by using `yarn install` instead of `npm install`.